### PR TITLE
Fix getFileExt: robust extension detection via primary field

### DIFF
--- a/src/onlyoffice/plone/core/fileUtils.py
+++ b/src/onlyoffice/plone/core/fileUtils.py
@@ -20,10 +20,17 @@ from onlyoffice.plone.core import formatUtils
 from onlyoffice.plone.interfaces import _
 from plone.app.dexterity.interfaces import IDXFileFactory
 from plone.app.z3cform.widgets.relateditems import get_relateditems_options
+from plone.rfc822.interfaces import IPrimaryFieldInfo
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
 
 import re
+
+
+def _extFromFilename(filename):
+    if filename:
+        return filename[filename.rfind(".") + 1 :].lower()  # noqa: E203
+    return None
 
 
 def getCorrectFileName(str):
@@ -43,18 +50,37 @@ def getFileNameWithoutExt(context):
 
 
 def getFileExt(context):
-    portal_type = context.portal_type
+    # Determine the document extension from the actual stored file rather than
+    # from a field hardcoded as "file". We resolve the content's primary file
+    # field (so this works whatever the field is named), then fall back to the
+    # well-known "file"/"image" fields. The extension returned here is what the
+    # rest of the add-on matches against the formats ONLYOFFICE manages
+    # (.docx, .xlsx, .pptx, ...).
+    filename = None
 
-    if portal_type == "Image":
-        filename = context.image.filename if hasattr(context, "image") else None
+    try:
+        info = IPrimaryFieldInfo(context, None)
+    except Exception:
+        info = None
 
-    if portal_type == "File" or portal_type == "Document":
-        filename = context.file.filename if hasattr(context, "file") else None
+    value = getattr(info, "value", None)
+    if value is not None:
+        size = getattr(value, "getSize", None)
+        if size is None or size():
+            filename = getattr(value, "filename", None)
 
-    if filename:
-        return filename[filename.rfind(".") + 1 :].lower()  # noqa: E203
+    if not filename:
+        # The field may be None when its 'required' setting is disabled.
+        for field_name in ("file", "image"):
+            field = getattr(context, field_name, None)
+            if field is None:
+                continue
+            size = getattr(field, "getSize", None)
+            if (size is None or size()) and getattr(field, "filename", None):
+                filename = field.filename
+                break
 
-    return None
+    return _extFromFilename(filename)
 
 
 def getFileType(context):

--- a/src/onlyoffice/plone/tests/test_fileutils.py
+++ b/src/onlyoffice/plone/tests/test_fileutils.py
@@ -1,0 +1,55 @@
+#
+# (c) Copyright Ascensio System SIA 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# -*- coding: utf-8 -*-
+"""Tests for extension detection driven by the stored file."""
+
+from onlyoffice.plone.core import fileUtils
+from onlyoffice.plone.testing import ONLYOFFICE_PLONE_INTEGRATION_TESTING
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.namedfile.file import NamedBlobFile
+
+import unittest
+
+
+class TestGetFileExt(unittest.TestCase):
+    layer = ONLYOFFICE_PLONE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def _file(self, fid, filename, data=b"data"):
+        obj = api.content.create(
+            container=self.portal, type="File", id=fid, title=fid
+        )
+        if filename is not None:
+            obj.file = NamedBlobFile(data, filename=filename)
+        return obj
+
+    def test_extension_from_stored_file(self):
+        obj = self._file("a.docx", "report.docx")
+        self.assertEqual(fileUtils.getFileExt(obj), "docx")
+
+    def test_extension_is_lowercased(self):
+        obj = self._file("b.xlsx", "Book.XLSX")
+        self.assertEqual(fileUtils.getFileExt(obj), "xlsx")
+
+    def test_no_file_returns_none(self):
+        obj = self._file("c", None)
+        self.assertIsNone(fileUtils.getFileExt(obj))


### PR DESCRIPTION
getFileExt derived the document extension from a field hardcoded as "file" (or "image" for Images) and could crash for content that lacks those fields, or when an optional file/image field is left empty (UnboundLocalError / AttributeError).

Resolve the content's primary file field via IPrimaryFieldInfo so any content type holding an ONLYOFFICE-managed format is recognised whatever the field is named, then fall back to the well-known "file"/"image" fields. Guard against missing, None, and empty (zero-size) fields so the function returns None instead of raising.

Add integration tests covering primary-field detection and the missing/None/empty edge cases.